### PR TITLE
fix scrollbar over command line blocks on Firefox

### DIFF
--- a/src/assets/user.scss
+++ b/src/assets/user.scss
@@ -80,6 +80,7 @@ html {
       text-align: left;
       border: 1px solid;
       overflow-y: hidden;
+      scrollbar-width: none;
       &::-webkit-scrollbar {
         display: none;
       }


### PR DESCRIPTION
Removes a scrollbar over blocks with command line install commands on the download page on Firefox browsers which don't support [::-webkit-scrollbar](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar) selectors to remove them.

Before:
![image](https://user-images.githubusercontent.com/45142318/209477118-d35ecada-9bbe-4b60-a93b-d4f66707c1af.png)

After:
![image](https://user-images.githubusercontent.com/45142318/209477190-0b993d66-d027-48c9-83de-66e341ea0373.png)
