### PR TITLE
Bug fix: Responsive Testimonial tweet containers

### DIFF
--- a/src/components/Testimonials/index.jsx
+++ b/src/components/Testimonials/index.jsx
@@ -76,7 +76,9 @@ export function Testimonials() {
       <div className="mx-auto mt-16 max-w-2xl px-8 sm:px-8 lg:mt-20 lg:max-w-none">
         <div className="masonry sm:columns-1 md:columns-2 lg:columns-3 xl:columns-4 2xl:columns-5 column-gap-6">
           {tweets.slice(0, visibleTweetsCount).map((tweetId) => (
-            <Tweet key={tweetId} id={tweetId} />
+            <div key={tweetId} className="break-inside-avoid">
+              <Tweet id={tweetId} />
+            </div>
           ))}
         </div>
 


### PR DESCRIPTION
Some tweet Container are being cut-off in different screen sizes.

Applied a fix to Address this issue using  "break-inside-avoid"

After Fix: 

The Tweet Container won't get cut-off as such we won't see the empty white container in website. **This fix ensure this issue never happens in all screen sizes.**

Actual:

<img width="1440" alt="Screenshot 2024-10-28 at 9 40 37 AM" src="https://github.com/user-attachments/assets/ede1b52e-6f99-4d74-90ff-b6c0cfda84c8">

Expected:

<img width="1440" alt="Screenshot 2024-10-28 at 9 25 33 AM" src="https://github.com/user-attachments/assets/7116ef61-2f25-4bec-b9da-9e3a18f599f4">

 