### PR TITLE
UI change faq section

### DIFF
--- a/src/components/Faqs.jsx
+++ b/src/components/Faqs.jsx
@@ -103,6 +103,7 @@ export function Faqs() {
   const flatFaqs = faqs.flat();
 
   return (
+// this section
     <section
       id="faq"
       aria-labelledby="faq-title"
@@ -116,6 +117,7 @@ export function Faqs() {
         height={946}
         unoptimized
       />
+
       <Container className="relative">
         <div className="mx-auto max-w-3xl">
           <h2
@@ -139,10 +141,10 @@ export function Faqs() {
             {flatFaqs.map((faq, index) => (
               <div
                 key={index}
-                className="rounded-2xl bg-white shadow-sm transition-shadow duration-300 hover:shadow-md"
+                className="rounded-2xl bg-white shadow-sm transition-shadow duration-300 hover:shadow-md border border-indigo-200"
               >
                 <button
-                  className="flex w-full items-center justify-between px-6 py-4 text-left"
+                  className="flex w-full items-center border-purple-200 justify-between px-6 py-4 text-left"
                   onClick={() => toggleQuestion(index)}
                 >
                   <span className="font-semibold text-slate-900">{faq.question}</span>

--- a/src/components/Faqs.jsx
+++ b/src/components/Faqs.jsx
@@ -142,7 +142,7 @@ export function Faqs() {
                 className="rounded-2xl bg-white shadow-sm transition-shadow duration-300 hover:shadow-md border border-indigo-200"
               >
                 <button
-                  className="flex w-full items-center border-purple-200 justify-between px-6 py-4 text-left"
+                  className="flex w-full items-center justify-between px-6 py-4 text-left"
                   onClick={() => toggleQuestion(index)}
                 >
                   <span className="font-semibold text-slate-900">{faq.question}</span>

--- a/src/components/Faqs.jsx
+++ b/src/components/Faqs.jsx
@@ -103,7 +103,6 @@ export function Faqs() {
   const flatFaqs = faqs.flat();
 
   return (
-// this section
     <section
       id="faq"
       aria-labelledby="faq-title"
@@ -117,7 +116,6 @@ export function Faqs() {
         height={946}
         unoptimized
       />
-
       <Container className="relative">
         <div className="mx-auto max-w-3xl">
           <h2


### PR DESCRIPTION
**UI CHANGE** FAQ Section

The faq Section require a border as the background and button has very less contrast.

Actual:
<img width="1440" alt="Screenshot 2024-10-28 at 2 11 21 PM" src="https://github.com/user-attachments/assets/9ae16192-05c7-4573-838f-c36b367ff709">

Expected:
<img width="1440" alt="Screenshot 2024-10-28 at 2 11 57 PM" src="https://github.com/user-attachments/assets/ebba175b-8e43-4625-b552-c550c1491f6c">

