### PR TITLE
✨ Pull Request: Add 'go to top' button to website

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -4,8 +4,16 @@ import { Container } from '@/components/Container';
 import { Logo } from '@/components/Logo';
 import { NavLink } from '@/components/NavLink';
 import { Icon } from '@iconify/react';
+import { Button } from './Button';
 
 export function Footer() {
+  function goToTop(){
+    let rootElement = document.documentElement;
+    rootElement.scrollTo({
+      top: 0,
+      behavior: "smooth"
+    })
+  }
   return (
     <footer className="relative z-10 bg-slate-50">
       <Container>
@@ -24,7 +32,7 @@ export function Footer() {
             </div>
           </nav>
         </div>
-        <div className="flex flex-col items-center border-t border-slate-400/10 py-10 sm:flex-row-reverse sm:justify-between">
+        <div className="flex flex-col items-center border-t border-slate-400/10 py-10 md:flex-row-reverse md:justify-between">
           <div className="flex items-center gap-x-6">
             <Link
               href="https://twitter.com/ResponsivelyApp"
@@ -65,6 +73,11 @@ export function Footer() {
           </p>
         </div>
       </Container>
+      <Button className='fixed right-2 bottom-2 goToTop'  color="green" style={{width: '40px', height: '40px', padding: '4px 8px'}} onClick={goToTop}>
+        <svg xmlns="http://www.w3.org/2000/svg" width={'40px'} height={'40px'} fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" className="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18" />
+        </svg>
+      </Button>
     </footer>
   );
 }


### PR DESCRIPTION
📓 Referenced Issue: 
Refs #1329

ℹ️ About the PR: 
Added a new button to the "Footer" component to allow users to navigate to the top of the website, using the pre-existing "Button" component. The button position is fixed to the bottom right part of the screen. 
To prevent some cases where the button was overlapping the "Discord" icon, I changed the breakpoint for "flex-row-reverse" and "justify-between" from "sm" to "md" on the "Copyright..." and social media logos div container.

🖼️ Testing Scenarios / Screenshots:
I tested the change on the following desktop browser and it renders properly: Safari, Firefox, Brave, and Microsoft Edge. 
Safari:
![Safari test](https://github.com/user-attachments/assets/773d5e00-4d22-4c64-b3f8-48938f8acd83)

Firefox:
![Firefox test](https://github.com/user-attachments/assets/e706f107-7472-481c-a76b-0f499c728fce)

Brave:
![Brave test on the "Download" page](https://github.com/user-attachments/assets/96a69e21-fa8d-4132-87c9-9cbc0717eb94)

Microsoft Edge:
![Microsoft Edge test](https://github.com/user-attachments/assets/9cd7a8e8-ae9f-4535-a3ad-31e6346cd003)