### PR TITLE
Fix: Ensure only one icon scales on hover in header by scoping 'group' class to each NavLink

### DIFF
--- a/src/components/StarButton/index.tsx
+++ b/src/components/StarButton/index.tsx
@@ -21,10 +21,11 @@ export const StarButton = () => {
   }, []);
 
   return (
-    <div className="group hidden md:block">
+    <div className="hidden md:block">
       <NavLink
         href="https://github.com/responsively-org/responsively-app/stargazers"
         target="_blank"
+        className='group'
       >
         <span className="flex items-center gap-1">
           <Icon
@@ -37,6 +38,7 @@ export const StarButton = () => {
       </NavLink>
       <NavLink
         href="/download"
+        className='group'
       >
         <span className="flex items-center gap-1">
           <Icon


### PR DESCRIPTION
### Fixed 
Fixes an issue where both icons in the `StarButton` component were scaling on hover due to shared `group` class.

### Problem
Both `<NavLink>` elements were children of a common parent with `group`, causing `group-hover:scale-125` to trigger on both icons.

### Fix
Moved the `group` class to each `NavLink` individually so that only the hovered button scales its icon.

### Tested
- Verified that each icon now scales independently when hovered.
- Verified functionality on both GitHub star and download buttons.

Fixes: #79
